### PR TITLE
[DO-567] Change logic of setting ToC

### DIFF
--- a/composables/states.ts
+++ b/composables/states.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { Toc, ParsedContent } from '@nuxt/content/dist/runtime/types'
+import { ParsedContent } from '@nuxt/content/dist/runtime/types'
 import { Ref } from 'vue'
 
-export const useToc = () => useState<Toc | null>('toc', () => null)
 export const useShowContentTree = () =>
   useState<boolean>('showContentTree', () => false)
 export const useTermPopup = () => {

--- a/composables/table-of-contents.ts
+++ b/composables/table-of-contents.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Toc, MarkdownParsedContent } from '@nuxt/content/dist/runtime/types'
+
+/**
+ *
+ * Provides table of contents reference
+ *
+ * @returns Table of contents reference
+ */
+export function useToc() {
+  return useState<Toc | null>('toc', () => null)
+}
+
+/**
+ *
+ * Automatically updates table of contents when document is changed
+ *
+ * @param doc Document to extract table of contents from
+ * @returns Function to stop watching document
+ */
+export function useTocUpdate(doc: Ref<MarkdownParsedContent | null>) {
+  const toc = useToc()
+
+  function updateToc() {
+    if (doc.value) {
+      toc.value = doc.value?.body?.toc ?? null
+    }
+  }
+
+  const stopWatchDoc = watch(doc, () => {
+    updateToc()
+  })
+
+  onMounted(() => {
+    updateToc()
+  })
+
+  onBeforeUnmount(() => {
+    stopWatchDoc()
+  })
+
+  return stopWatchDoc
+}

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -66,7 +66,7 @@ export default defineComponent({
       layout: 'docs'
     })
     const route = useRoute()
-    const toc = useToc()
+
     const { data: doc } = useAsyncData('page-data' + route.path, async () => {
       const docPromise = queryContent<DocParsedContent>(route.path).findOne()
       const surroundPromise = queryContent()
@@ -84,23 +84,7 @@ export default defineComponent({
       }
     })
 
-    function updateToc() {
-      if (doc.value) {
-        toc.value = doc.value?.body?.toc ?? null
-      }
-    }
-
-    onMounted(() => {
-      updateToc()
-    })
-
-    const stopWatchDoc = watch(doc, () => {
-      updateToc()
-    })
-
-    onBeforeUnmount(() => {
-      stopWatchDoc()
-    })
+    useTocUpdate(doc)
 
     return {
       doc

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -83,7 +83,24 @@ export default defineComponent({
         after: surround[1] as ParsedContent
       }
     })
-    toc.value = doc.value?.body?.toc ?? null
+
+    function updateToc() {
+      if (doc.value) {
+        toc.value = doc.value?.body?.toc ?? null
+      }
+    }
+
+    onMounted(() => {
+      updateToc()
+    })
+
+    const stopWatchDoc = watch(doc, () => {
+      updateToc()
+    })
+
+    onBeforeUnmount(() => {
+      stopWatchDoc()
+    })
 
     return {
       doc


### PR DESCRIPTION
Now ToC is setup inside Vue lifecycle hooks + watcher for documentation page data.

I built production version locally, and it looks like it works.