### PR TITLE
[DO-596] Text breaking in next/prev buttons

### DIFF
--- a/components/ep/layout/SurroundDocCard.vue
+++ b/components/ep/layout/SurroundDocCard.vue
@@ -33,7 +33,7 @@ defineProps<{
   <NuxtLink
     :to="withTrailingSlash(doc._path ?? '')"
     class="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
-    style="word-wrap: break-word; word-break: keep-all;"
+    style="word-wrap: break-word word-break: keep-all"
   >
     <div>
       <div v-if="direction === 'before'" class="mb-2">

--- a/components/ep/layout/SurroundDocCard.vue
+++ b/components/ep/layout/SurroundDocCard.vue
@@ -33,7 +33,7 @@ defineProps<{
   <NuxtLink
     :to="withTrailingSlash(doc._path ?? '')"
     class="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
-    style="word-wrap: break-word word-break: keep-all"
+    style="word-wrap: break-word; word-break: keep-all"
   >
     <div>
       <div v-if="direction === 'before'" class="mb-2">

--- a/components/ep/layout/SurroundDocCard.vue
+++ b/components/ep/layout/SurroundDocCard.vue
@@ -32,8 +32,7 @@ defineProps<{
 <template>
   <NuxtLink
     :to="withTrailingSlash(doc._path ?? '')"
-    class="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
-    style="word-wrap: break-word; word-break: keep-all"
+    class="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700 break-words"
   >
     <div>
       <div v-if="direction === 'before'" class="mb-2">
@@ -53,7 +52,7 @@ defineProps<{
         </span>
       </div>
       <h4 class="text-xl font-bold">{{ doc.title }}</h4>
-      <p>{{ doc.description }}</p>
+      <p class="break-words">{{ doc.description }}</p>
     </div>
   </NuxtLink>
 </template>

--- a/components/ep/layout/SurroundDocCard.vue
+++ b/components/ep/layout/SurroundDocCard.vue
@@ -33,6 +33,7 @@ defineProps<{
   <NuxtLink
     :to="withTrailingSlash(doc._path ?? '')"
     class="block max-w-sm p-6 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
+    style="word-wrap: break-word; word-break: keep-all;"
   >
     <div>
       <div v-if="direction === 'before'" class="mb-2">


### PR DESCRIPTION
Closes #46 

Problem seems to be fixed, but wider code blocks make our buttons look not so good. I believe, it will work fine after fixing issue with wide code blocks